### PR TITLE
Add request timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const request = async (route) => {
 	const res = await fetch(endpoint + route, {
 		mode: 'cors',
 		redirect: 'follow',
-		headers: {'User-Agent': userAgent}
+		headers: {'User-Agent': userAgent},
+		timeout: 2500
 	})
 	if (!res.ok) {
 		const err = new Error(res.statusText)


### PR DESCRIPTION
Since the domain wifi.sncf is actually registered as a valid TLD, using this package outside of a SNCF WiFi system causes infinite(?) waiting time. Adding a request timeout fixes that 🙌